### PR TITLE
Modify nuget push commands to skip duplicates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,6 @@ jobs:
     - run: dotnet nuget add source --username holistic-net --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/holistic-net/index.json"
     - run: dotnet build --configuration Release
     - run: dotnet pack --configuration Release --output ./nupkgs
-    - run: dotnet nuget push "bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
-    - run: dotnet nuget push "bin/Release/*.nupkg" --api-key ${{ secrets.NUGET_ORG_TOKEN }} --source https://api.nuget.org/v3/index.json
+    - run: dotnet nuget push "bin/Release/*.nupkg" --api-key ${{ secrets.GITHUB_TOKEN }} --source "github" --skip-duplicate
+    - run: dotnet nuget push "bin/Release/*.nupkg" --api-key ${{ secrets.NUGET_ORG_TOKEN }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     


### PR DESCRIPTION
Added --skip-duplicate option to nuget push commands.